### PR TITLE
simplify configuration tests by removing mocking

### DIFF
--- a/tests/Camunda8.Tests/ConfigurationServiceTest.cs
+++ b/tests/Camunda8.Tests/ConfigurationServiceTest.cs
@@ -8,18 +8,21 @@ public class ConfigurationServiceTest
     [Fact]
     public void TestEnvironmentVariableConfiguration()
     {
-        var mockEnvironment = new Mock<IConfiguration>();
-        mockEnvironment.Setup(e => e.GetValue<string>("ZEEBE_CLIENT_ID"))
-            .Returns("test-client-id");
-        mockEnvironment.Setup(e => e.GetValue<string>("ZEEBE_CLIENT_SECRET"))
-            .Returns("test-client-secret");
-        mockEnvironment.Setup(e => e.GetValue<string>("CAMUNDA_AUTH_STRATEGY"))
-            .Returns("OAUTH");
+        var environmentSettings =
+            new Dictionary<string, string?> {
+                {"ZEEBE_CLIENT_ID", "test-client-id"},
+                {"ZEEBE_CLIENT_SECRET", "test-client-secret"},
+                {"CAMUNDA_AUTH_STRATEGY", "OAUTH"}
+            };
+
+        IConfiguration environmentConfiguration = new ConfigurationBuilder()
+            .AddInMemoryCollection(environmentSettings)
+            .Build();
 
         var explicitConfiguration = new Camunda8Configuration();
         explicitConfiguration.CAMUNDA_AUTH_STRATEGY = Camunda8AuthStrategy.None;
 
-        var configuration = new ConfigurationService(mockEnvironment.Object, explicitConfiguration);
+        var configuration = new ConfigurationService(environmentConfiguration, explicitConfiguration);
         Assert.Equal(Camunda8AuthStrategy.OAuth, configuration.Configuration.CAMUNDA_AUTH_STRATEGY);
         Assert.Equal("test-client-id", configuration.Configuration.ZEEBE_CLIENT_ID);
         Assert.Equal("test-client-secret", configuration.Configuration.ZEEBE_CLIENT_SECRET);


### PR DESCRIPTION
I discovered, I think, that the reason the tests were failing is because not everything was mocked that needed to be mocked. Specifically, [this line](https://github.com/jwulf/Camunda8DotNetSDK/blob/24909d7ce4e7e91ab10c85cdd0627db011559663/src/Camunda8/Services/ConfigurationService.cs#L10) was not mocked for the configuration passed in during the test:

```c#
        var baseConfiguration = configuration.Get<Camunda8Configuration>()!;
```

This seemed to be resulting in the merge function having basically nothing for the environment configuration. (Side note: I think I remember that there was a way with Moq to tell mock objects to blow up when something was accessed that you didn't configure during setup, which might have been a way to identify this sooner.)

I did a **Boomer Search** using an actual search engine 😱 to find out how to mock IConfiguration objects, and it turned up [this answer](https://stackoverflow.com/a/68985242), which suggests _not_ mocking them, but instead using a dictionary. I find it to be more enjoyable to read, and it seems like not mocking is preferable to mocking whenever possible.

This still leaves a failing test -- but I think it's because the `CAMUNDA_AUTH_STRATEGY` value is not being handled properly by the merge. I see all the environment variables in the merged result, nothing from the explicit one. This seems incorrect, but a mostly good start!

Hope this helps!

